### PR TITLE
Added netstandard 2.0 support

### DIFF
--- a/Intacct.SDK/Intacct.SDK.csproj
+++ b/Intacct.SDK/Intacct.SDK.csproj
@@ -20,11 +20,13 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1" />
     <PackageReference Include="NLog" Version="4.5.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1" />
     <PackageReference Include="NLog" Version="4.5.3" />
   </ItemGroup>

--- a/Intacct.SDK/Intacct.SDK.csproj
+++ b/Intacct.SDK/Intacct.SDK.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <PackageId>Intacct.SDK</PackageId>
     <PackageVersion>2.1.0</PackageVersion>
     <Authors>intacct</Authors>
@@ -13,14 +13,19 @@
     <Copyright>Copyright © 2019 Sage Intacct, Inc.</Copyright>
     <PackageTags>intacct sdk sage</PackageTags>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1" />
     <PackageReference Include="NLog" Version="4.5.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1" />
+    <PackageReference Include="NLog" Version="4.5.3" />
   </ItemGroup>
 </Project>

--- a/Intacct.SDK/Intacct.SDK.csproj
+++ b/Intacct.SDK/Intacct.SDK.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1" />
     <PackageReference Include="NLog" Version="4.5.3" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## System Requirements
 
 * You must have an active Sage Intacct Web Services Developer license
-* .NET Core 1.0 or .NET Framework 4.6.1. The SDK targets [.NET Standard 1.6][dotnet-standard].
+* .NET Core 1.0 or .NET Framework 4.6.1. The SDK targets [.NET Standard 1.6][dotnet-standard] and [.NET Standard 2.0][dotnet-standard].
 
 [intacct]: http://www.intacct.com
 [ia-developer]: https://developer.intacct.com/


### PR DESCRIPTION
Summary of changes:

- added netstandard2.0 as a target framework
- updated readme to reflect the support of netstandard2.0
- removed `Microsoft.Extensions.Configuration.Abstractions` from netstandard2.0 target as it is already implicitly referenced by `Microsoft.Extensions.Configuration`
- removed `System.Net.Http` as netstandard2.0 supports it
- removed `System.Net.NameResolution` as it seems to be unused