### PR TITLE
Add TaskId to AP Bill - BillLineCreate

### DIFF
--- a/Intacct.SDK.Tests/Functions/AccountsPayable/BillLineCreateTest.cs
+++ b/Intacct.SDK.Tests/Functions/AccountsPayable/BillLineCreateTest.cs
@@ -65,7 +65,7 @@ namespace Intacct.SDK.Tests.Functions.AccountsPayable
         </customfield>
     </customfields>
     <projectid>Project1</projectid>
-	<taskid>Task1</taskid>
+    <taskid>Task1</taskid>
     <customerid>Customer1</customerid>
     <vendorid>Vendor1</vendorid>
     <employeeid>Employee1</employeeid>
@@ -89,7 +89,7 @@ namespace Intacct.SDK.Tests.Functions.AccountsPayable
                 LocationId = "Location1",
                 DepartmentId = "Department1",
                 ProjectId = "Project1",
-				TaskId = "Task1",
+                TaskId = "Task1",
                 CustomerId = "Customer1",
                 VendorId = "Vendor1",
                 EmployeeId = "Employee1",

--- a/Intacct.SDK.Tests/Functions/AccountsPayable/BillLineCreateTest.cs
+++ b/Intacct.SDK.Tests/Functions/AccountsPayable/BillLineCreateTest.cs
@@ -65,6 +65,7 @@ namespace Intacct.SDK.Tests.Functions.AccountsPayable
         </customfield>
     </customfields>
     <projectid>Project1</projectid>
+	<taskid>Task1</taskid>
     <customerid>Customer1</customerid>
     <vendorid>Vendor1</vendorid>
     <employeeid>Employee1</employeeid>
@@ -88,6 +89,7 @@ namespace Intacct.SDK.Tests.Functions.AccountsPayable
                 LocationId = "Location1",
                 DepartmentId = "Department1",
                 ProjectId = "Project1",
+				TaskId = "Task1",
                 CustomerId = "Customer1",
                 VendorId = "Vendor1",
                 EmployeeId = "Employee1",

--- a/Intacct.SDK/Functions/AccountsPayable/AbstractBillLine.cs
+++ b/Intacct.SDK/Functions/AccountsPayable/AbstractBillLine.cs
@@ -48,8 +48,8 @@ namespace Intacct.SDK.Functions.AccountsPayable
         public string LocationId;
 
         public string ProjectId;
-		
-		public string TaskId;
+
+        public string TaskId;
 
         public string CustomerId;
 

--- a/Intacct.SDK/Functions/AccountsPayable/AbstractBillLine.cs
+++ b/Intacct.SDK/Functions/AccountsPayable/AbstractBillLine.cs
@@ -48,6 +48,8 @@ namespace Intacct.SDK.Functions.AccountsPayable
         public string LocationId;
 
         public string ProjectId;
+		
+		public string TaskId;
 
         public string CustomerId;
 

--- a/Intacct.SDK/Functions/AccountsPayable/BillLineCreate.cs
+++ b/Intacct.SDK/Functions/AccountsPayable/BillLineCreate.cs
@@ -51,7 +51,7 @@ namespace Intacct.SDK.Functions.AccountsPayable
             xml.WriteCustomFieldsExplicit(CustomFields);
 
             xml.WriteElement("projectid", ProjectId);
-			xml.WriteElement("taskid", TaskId);
+            xml.WriteElement("taskid", TaskId);
             xml.WriteElement("customerid", CustomerId);
             xml.WriteElement("vendorid", VendorId);
             xml.WriteElement("employeeid", EmployeeId);

--- a/Intacct.SDK/Functions/AccountsPayable/BillLineCreate.cs
+++ b/Intacct.SDK/Functions/AccountsPayable/BillLineCreate.cs
@@ -51,6 +51,7 @@ namespace Intacct.SDK.Functions.AccountsPayable
             xml.WriteCustomFieldsExplicit(CustomFields);
 
             xml.WriteElement("projectid", ProjectId);
+			xml.WriteElement("taskid", TaskId);
             xml.WriteElement("customerid", CustomerId);
             xml.WriteElement("vendorid", VendorId);
             xml.WriteElement("employeeid", EmployeeId);

--- a/Intacct.SDK/Functions/AccountsPayable/BillLineUpdate.cs
+++ b/Intacct.SDK/Functions/AccountsPayable/BillLineUpdate.cs
@@ -70,7 +70,7 @@ namespace Intacct.SDK.Functions.AccountsPayable
             xml.WriteCustomFieldsExplicit(CustomFields);
 
             xml.WriteElement("projectid", ProjectId);
-			xml.WriteElement("taskid", TaskId);
+            xml.WriteElement("taskid", TaskId);
             xml.WriteElement("customerid", CustomerId);
             xml.WriteElement("vendorid", VendorId);
             xml.WriteElement("employeeid", EmployeeId);

--- a/Intacct.SDK/Functions/AccountsPayable/BillLineUpdate.cs
+++ b/Intacct.SDK/Functions/AccountsPayable/BillLineUpdate.cs
@@ -70,6 +70,7 @@ namespace Intacct.SDK.Functions.AccountsPayable
             xml.WriteCustomFieldsExplicit(CustomFields);
 
             xml.WriteElement("projectid", ProjectId);
+			xml.WriteElement("taskid", TaskId);
             xml.WriteElement("customerid", CustomerId);
             xml.WriteElement("vendorid", VendorId);
             xml.WriteElement("employeeid", EmployeeId);


### PR DESCRIPTION
It looks like all the other dimensions are included, except TaskId. Adding this will allow us to properly code the Task dimension to AP Bills.

Task Id is included on the API docs. https://developer.intacct.com/api/accounts-payable/bills/#create-bill