### PR TITLE
Update PurchasingTransactionApprove.cs

### DIFF
--- a/Intacct.SDK/Functions/Purchasing/PurchasingTransactionApprove.cs
+++ b/Intacct.SDK/Functions/Purchasing/PurchasingTransactionApprove.cs
@@ -33,7 +33,7 @@ namespace Intacct.SDK.Functions.Purchasing
             
             xml.WriteStartElement("PODOCUMENT");
             
-            xml.WriteElement("DOCID", ExternalId);
+            xml.WriteElement("DOCID", DocumentId);
             
             xml.WriteElement("COMMENT", Comment);
             


### PR DESCRIPTION
I believe the DOCID element should reference the DocumentId, not the ExternalId