### PR TITLE
Use DocumentId instead of ExternalId on PurchaseTransaction approvals and declines

### DIFF
--- a/Intacct.SDK.Tests/Functions/Purchasing/PurchasingTransactionApproveTest.cs
+++ b/Intacct.SDK.Tests/Functions/Purchasing/PurchasingTransactionApproveTest.cs
@@ -36,7 +36,7 @@ namespace Intacct.SDK.Tests.Functions.Purchasing
 
             PurchasingTransactionApprove record = new PurchasingTransactionApprove("unittest")
             {
-                ExternalId = "Purchase Order-PO0213",
+                DocumentId = "Purchase Order-PO0213",
                 Comment = "Final approval for the quarter"
             };
 

--- a/Intacct.SDK.Tests/Functions/Purchasing/PurchasingTransactionDeclineTest.cs
+++ b/Intacct.SDK.Tests/Functions/Purchasing/PurchasingTransactionDeclineTest.cs
@@ -37,7 +37,7 @@ namespace Intacct.SDK.Tests.Functions.Purchasing
             PurchasingTransactionDecline record = new PurchasingTransactionDecline("unittest")
 
             {
-                ExternalId = "Purchase Order-PO0213",
+                DocumentId = "Purchase Order-PO0213",
                 Comment = "Need to wait on this"
             };
 

--- a/Intacct.SDK/Functions/Purchasing/PurchasingTransactionApprove.cs
+++ b/Intacct.SDK/Functions/Purchasing/PurchasingTransactionApprove.cs
@@ -33,7 +33,7 @@ namespace Intacct.SDK.Functions.Purchasing
             
             xml.WriteStartElement("PODOCUMENT");
             
-            xml.WriteElement("DOCID", ExternalId);
+            xml.WriteElement("DOCID", DocumentId);
             
             xml.WriteElement("COMMENT", Comment);
             

--- a/Intacct.SDK/Functions/Purchasing/PurchasingTransactionDecline.cs
+++ b/Intacct.SDK/Functions/Purchasing/PurchasingTransactionDecline.cs
@@ -33,7 +33,7 @@ namespace Intacct.SDK.Functions.Purchasing
             
             xml.WriteStartElement("PODOCUMENT");
             
-            xml.WriteElement("DOCID", ExternalId);
+            xml.WriteElement("DOCID", DocumentId);
             
             xml.WriteElement("COMMENT", Comment);
             


### PR DESCRIPTION
I believe this should be using DocumentId and not the ExternalId.