### PR TITLE
Classes to support the non-legacy version of create accounts receivable payment API

### DIFF
--- a/Intacct.SDK.Tests/Functions/AccountsReceivable/ArPaymentCreate2Test.cs
+++ b/Intacct.SDK.Tests/Functions/AccountsReceivable/ArPaymentCreate2Test.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * Copyright 2020 Sage Intacct, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Intacct.SDK.Functions.AccountsReceivable;
+using Intacct.SDK.Tests.Xml;
+using System;
+using Xunit;
+
+namespace Intacct.SDK.Tests.Functions.AccountsReceivable
+{
+    public class ArPaymentCreate2Test : XmlObjectTestHelper
+    {
+        [Fact]
+        public void GetXmlTest()
+        {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<function controlid=""unittest"">
+    <create>
+        <arpymt>
+            <paymentmethod>Printed Check</paymentmethod>
+            <customerid>C0020</customerid>
+            <docnumber>1000</docnumber>
+            <description>Test Memo</description>
+            <receiptdate>06/30/2021</receiptdate>
+            <amounttopay />
+            <trx_amounttopay>1922.12</trx_amounttopay>
+            <prbatch>123</prbatch>
+            <whenpaid>07/01/2021</whenpaid>
+            <overpaymentamount />
+            <overpaymentlocationid>1020</overpaymentlocationid>
+            <overpaymentdepartmentid>900</overpaymentdepartmentid>
+        </arpymt>
+    </create>
+</function>";
+
+            ArPaymentCreate2 record = new ArPaymentCreate2("unittest")
+            {
+                CustomerId = "C0020",
+                TransactionPaymentAmount = 1922.12M,
+                SummaryRecordNo = 123,
+                ReceivedDate = new DateTime(2021, 06, 30),
+                PaymentMethod = "Printed Check",
+                ReferenceNumber = "1000",
+                Description = "Test Memo",
+                OverpaymentDepartmentId = "900",
+                OverpaymentLocationId = "1020",
+                WhenPaidDate = new DateTime(2021, 07, 01)
+            };
+
+            this.CompareXml(expected, record);
+        }
+    }
+}

--- a/Intacct.SDK.Tests/Intacct.SDK.Tests.csproj
+++ b/Intacct.SDK.Tests/Intacct.SDK.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net4.6.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;net4.6.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>

--- a/Intacct.SDK.Tests/Xml/XmlObjectTestHelper.cs
+++ b/Intacct.SDK.Tests/Xml/XmlObjectTestHelper.cs
@@ -1,22 +1,22 @@
 ﻿/*
  * Copyright 2020 Sage Intacct, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
- * use this file except in compliance with the License. You may obtain a copy 
+ * use this file except in compliance with the License. You may obtain a copy
  * of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * or in the "LICENSE" file accompanying this file. This file is distributed on 
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
- * express or implied. See the License for the specific language governing 
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 
+using Intacct.SDK.Xml;
 using System.IO;
 using System.Text;
 using System.Xml;
-using Intacct.SDK.Xml;
 using Xunit;
 
 namespace Intacct.SDK.Tests.Xml
@@ -34,14 +34,15 @@ namespace Intacct.SDK.Tests.Xml
             };
 
             IaXmlWriter xml = new IaXmlWriter(stream, xmlSettings);
-            
+
             apiFunction.WriteXml(ref xml);
 
             xml.Flush();
             stream.Position = 0;
             StreamReader reader = new StreamReader(stream);
-            
-            Assert.Equal(expected, reader.ReadToEnd());
+
+            var foo = reader.ReadToEnd();
+            Assert.Equal(expected, foo);
         }
     }
 }

--- a/Intacct.SDK/Functions/AccountsReceivable/AbstractArPayment2.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/AbstractArPayment2.cs
@@ -1,0 +1,123 @@
+﻿/*
+ * Copyright 2020 Sage Intacct, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace Intacct.SDK.Functions.AccountsReceivable
+{
+    public abstract class AbstractArPayment2 : AbstractFunction
+    {
+        /// <summary>
+        /// ARPYMTDETAILS
+        /// </summary>
+        public List<ArPaymentItem2> ApplyToTransactions = new List<ArPaymentItem2>();
+
+        /// <summary>
+        /// FINANCIALENTITY
+        /// </summary>
+        public string BankAccountId;
+
+        /// <summary>
+        /// BASECURR
+        /// </summary>
+        public string BaseCurrency;
+
+        /// <summary>
+        /// AMOUNTOPAY
+        /// </summary>
+        public decimal? BasePaymentAmount;
+
+        public string BillToPayName;
+        public string CustomerId;
+        public string Description;
+
+        /// <summary>
+        /// EXCH_RATE_TYPE_ID
+        /// </summary>
+        public string ExchangeRateType;
+
+        /// <summary>
+        /// EXCHANGE_RATE
+        /// </summary>
+        public decimal? ExchangeRateValue;
+
+        /// <summary>
+        /// OVERPAYMENTAMOUNT
+        /// </summary>
+        public decimal? OverpaymentAmount;
+
+        public string OverpaymentDepartmentId;
+        public string OverpaymentLocationId;
+
+        /// <summary>
+        /// PAYMENTDATE
+        /// </summary>
+        public DateTime? PaymentDate;
+
+        public string PaymentMethod;
+
+        /// <summary>
+        /// RECEIPTDATE
+        /// </summary>
+        public DateTime? ReceivedDate;
+
+        /// <summary>
+        /// DOCNUMBER
+        /// </summary>
+        public string ReferenceNumber;
+
+        /// <summary>
+        /// PRBATCH
+        /// </summary>
+        public int? SummaryRecordNo;
+
+        /// <summary>
+        /// CURRENCY
+        /// </summary>
+        public string TransactionCurrency;
+
+        /// <summary>
+        /// TRX_AMOUNTTOPAY
+        /// </summary>
+        public decimal? TransactionPaymentAmount;
+
+        /// <summary>
+        /// UNDEPOSITEDACCOUNTNO
+        /// </summary>
+        public string UndepositedFundsGlAccountNo;
+
+        /// <summary>
+        /// WHENPAID
+        /// </summary>
+        public DateTime? WhenPaidDate;
+
+        #region Unmappable AbstractArPayment Fields
+
+        /// public string CreditCardType;
+
+        // public DateTime? ExchangeRateDate;
+
+        // public string AuthorizationCode;
+
+        // public int? RecordNo;
+
+        #endregion Unmappable AbstractArPayment Fields
+
+        protected AbstractArPayment2(string controlId = null) : base(controlId)
+        {
+        }
+    }
+}

--- a/Intacct.SDK/Functions/AccountsReceivable/ArPaymentCreate2.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/ArPaymentCreate2.cs
@@ -1,0 +1,130 @@
+﻿/*
+ * Copyright 2020 Sage Intacct, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Intacct.SDK.Xml;
+
+namespace Intacct.SDK.Functions.AccountsReceivable
+{
+    /// <summary>
+    /// This class creates a payment using the non-legacy version of the API.
+    /// </summary>
+    public class ArPaymentCreate2 : AbstractArPayment2
+    {
+        public ArPaymentCreate2(string controlId = null) : base(controlId)
+        {
+        }
+
+        public override void WriteXml(ref IaXmlWriter xml)
+        {
+            xml.WriteStartElement("function");
+            xml.WriteAttribute("controlid", ControlId, true);
+
+            xml.WriteStartElement("create");
+
+            xml.WriteStartElement("arpymt");
+
+            if (!string.IsNullOrWhiteSpace(UndepositedFundsGlAccountNo))
+            {
+                xml.WriteElement("undepositedaccountno", BankAccountId); // undepfundsacct
+            }
+            else
+            {
+                xml.WriteElement("financialentity", BankAccountId); // bankaccountid
+            }
+
+            xml.WriteElement("paymentmethod", PaymentMethod, true);
+            xml.WriteElement("customerid", CustomerId, true);
+            xml.WriteElement("docnumber", ReferenceNumber); // "refid"
+            xml.WriteElement("description", Description);
+
+            //if (ExchangeRateDate.HasValue)
+            //{
+            //    xml.WriteStartElement("exchratedate");
+            //    xml.WriteDateSplitElements2(ExchangeRateDate.Value);
+            //    xml.WriteEndElement(); //exchratedate
+            //}
+
+            if (!string.IsNullOrWhiteSpace(ExchangeRateType))
+            {
+                xml.WriteElement("exch_rate_type_id", ExchangeRateType); // "exchratetype"
+            }
+            else if (ExchangeRateValue.HasValue)
+            {
+                xml.WriteElement("exchange_rate", ExchangeRateValue); // "exchrate"
+            }
+            else if (!string.IsNullOrWhiteSpace(BaseCurrency) || !string.IsNullOrWhiteSpace(TransactionCurrency))
+            {
+                xml.WriteElement("exchratetype", ExchangeRateType, true);
+            }
+
+            xml.WriteStartElement("receiptdate"); // "datereceived"
+            xml.WriteDateMMddyyyy(ReceivedDate.Value); // Required element
+            xml.WriteEndElement(); //receiptdate
+
+            if (PaymentDate.HasValue)
+            {
+                xml.WriteStartElement("paymentdate");
+                xml.WriteDateMMddyyyy(PaymentDate.Value);
+                xml.WriteEndElement(); //paymentdate
+            }
+
+            xml.WriteElement("amounttopay", BasePaymentAmount, true); // "translatedamount"
+            xml.WriteElement("trx_amounttopay", TransactionPaymentAmount, true); // paymentamount
+
+            xml.WriteElement("prbatch", SummaryRecordNo); // batchkey
+
+            if (WhenPaidDate.HasValue)
+            {
+                xml.WriteStartElement("whenpaid");
+                xml.WriteDateMMddyyyy(WhenPaidDate.Value);
+                xml.WriteEndElement(); //paymentdate
+            }
+
+            xml.WriteElement("currency", TransactionCurrency);
+            xml.WriteElement("basecurr", BaseCurrency);
+
+            xml.WriteElement("undepositedaccountno", UndepositedFundsGlAccountNo);
+
+            xml.WriteElement("overpaymentamount", OverpaymentAmount, true);
+            xml.WriteElement("overpaymentlocationid", OverpaymentLocationId); // "overpaylocid"
+            xml.WriteElement("overpaymentdepartmentid", OverpaymentDepartmentId); // "overpaydeptid"
+
+            xml.WriteElement("billtopayname", BillToPayName);
+
+            //xml.WriteElement("cctype", CreditCardType);
+            //xml.WriteElement("authcode", AuthorizationCode);
+
+            if (ApplyToTransactions.Count > 0)
+            {
+                xml.WriteStartElement("arpymtdetails"); // "arpaymentitem"
+
+                foreach (ArPaymentItem2 applyToTransaction in ApplyToTransactions)
+                {
+                    applyToTransaction.WriteXml(ref xml);
+                }
+
+                xml.WriteEndElement(); // arpymtdetails
+            }
+
+            // TODO online payment methods
+
+            xml.WriteEndElement(); //create
+
+            xml.WriteEndElement(); //arpymt
+
+            xml.WriteEndElement(); //function
+        }
+    }
+}

--- a/Intacct.SDK/Functions/AccountsReceivable/ArPaymentItem2.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/ArPaymentItem2.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Copyright 2020 Sage Intacct, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Intacct.SDK.Xml;
+
+namespace Intacct.SDK.Functions.AccountsReceivable
+{
+    public class ArPaymentItem2 : IXmlObject
+    {
+        public decimal? AmountToApply;
+        public int? ApplyToRecordId;
+
+        public ArPaymentItem2()
+        {
+        }
+
+        public void WriteXml(ref IaXmlWriter xml)
+        {
+            xml.WriteStartElement("arpymtdetail"); // "arpaymentitem"
+
+            xml.WriteElement("recordkey", ApplyToRecordId, true); // "invoicekey"
+            xml.WriteElement("trx_paymentamount", AmountToApply, true); // "amount"
+
+            xml.WriteEndElement(); // arpymtdetail
+        }
+    }
+}

--- a/Intacct.SDK/Intacct.SDK.csproj
+++ b/Intacct.SDK/Intacct.SDK.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <PackageId>Intacct.SDK</PackageId>
-    <PackageVersion>3.0.0</PackageVersion>
+    <PackageVersion>3.0.1</PackageVersion>
     <Authors>intacct</Authors>
     <AssemblyTitle>Sage Intacct SDK</AssemblyTitle>
     <Description>Sage Intacct SDK for .NET</Description>
@@ -15,11 +15,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
-    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="NLog" Version="4.7.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>

--- a/Intacct.SDK/Intacct.SDK.csproj
+++ b/Intacct.SDK/Intacct.SDK.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <PackageId>Intacct.SDK</PackageId>
-    <PackageVersion>3.0.1</PackageVersion>
+    <PackageVersion>3.1.0</PackageVersion>
     <Authors>intacct</Authors>
     <AssemblyTitle>Sage Intacct SDK</AssemblyTitle>
     <Description>Sage Intacct SDK for .NET</Description>
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="NLog" Version="4.7.6" />
+    <PackageReference Include="NLog" Version="4.7.8" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>

--- a/Intacct.SDK/Xml/IaXmlWriter.cs
+++ b/Intacct.SDK/Xml/IaXmlWriter.cs
@@ -143,6 +143,11 @@ namespace Intacct.SDK.Xml
             }
         }
 
+        public void WriteDateMMddyyyy(DateTime date)
+        {
+            _writer.WriteRaw(date.ToString("MM/dd/yyyy"));
+        }
+
         public void WriteDateSplitElements(DateTime date, bool writeNull = true)
         {
             WriteElement("year", date.ToString("yyyy"), writeNull);

--- a/Intacct.SDK/Xml/IaXmlWriter.cs
+++ b/Intacct.SDK/Xml/IaXmlWriter.cs
@@ -1,29 +1,27 @@
 ﻿/*
  * Copyright 2020 Sage Intacct, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
- * use this file except in compliance with the License. You may obtain a copy 
+ * use this file except in compliance with the License. You may obtain a copy
  * of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * or in the "LICENSE" file accompanying this file. This file is distributed on 
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
- * express or implied. See the License for the specific language governing 
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Xml;
 
 namespace Intacct.SDK.Xml
 {
     public class IaXmlWriter : XmlWriter
     {
-
         public const string IntacctDateFormat = "MM/dd/yyyy";
 
         public const string IntacctDateTimeFormat = "MM/dd/yyyy HH:mm:ss";
@@ -31,140 +29,14 @@ namespace Intacct.SDK.Xml
         public const string IntacctMultiSelectGlue = "#~#";
 
         private readonly XmlWriter _writer;
-        
-        public override WriteState WriteState => _writer.WriteState;
 
         public IaXmlWriter(Stream output, XmlWriterSettings settings)
         {
             _writer = Create(output, settings);
         }
 
+        public override WriteState WriteState => _writer.WriteState;
 
-        public override void WriteStartDocument()
-        {
-            _writer.WriteStartDocument();
-        }
-
-        public override void WriteStartDocument(bool standalone)
-        {
-            _writer.WriteStartDocument(standalone);
-        }
-
-        public override void WriteEndDocument()
-        {
-            _writer.WriteEndDocument();
-        }
-
-        public override void WriteDocType(string name, string pubid, string sysid, string subset)
-        {
-            _writer.WriteDocType(name, pubid, sysid, subset);
-        }
-        
-        public new void WriteStartElement(string localName)
-        {
-            _writer.WriteStartElement(localName);
-        }
-
-        public new void WriteStartElement(string localName, string ns)
-        {
-            _writer.WriteStartElement(localName, ns);
-        }
-
-        public override void WriteStartElement(string prefix, string localName, string ns)
-        {
-            _writer.WriteStartElement(prefix, localName, ns);
-        }
-
-        public override void WriteEndElement()
-        {
-            _writer.WriteEndElement();
-        }
-
-        public override void WriteFullEndElement()
-        {
-            _writer.WriteFullEndElement();
-        }
-
-        public new void WriteStartAttribute(string localName)
-        {
-            _writer.WriteStartAttribute(localName);
-        }
-
-        public new void WriteStartAttribute(string localName, string ns)
-        {
-            _writer.WriteStartAttribute(localName, ns);
-        }
-
-        public override void WriteStartAttribute(string prefix, string localName, string ns)
-        {
-            _writer.WriteStartAttribute(prefix, localName, ns);
-        }
-
-        public override void WriteEndAttribute()
-        {
-            _writer.WriteEndAttribute();
-        }
-
-        public override void WriteCData(string text)
-        {
-            _writer.WriteCData(text);
-        }
-
-        public override void WriteComment(string text)
-        {
-            _writer.WriteComment(text);
-        }
-
-        public override void WriteProcessingInstruction(string name, string text)
-        {
-            _writer.WriteProcessingInstruction(name, text);
-        }
-
-        public override void WriteEntityRef(string name)
-        {
-            _writer.WriteEntityRef(name);
-        }
-
-        public override void WriteCharEntity(char ch)
-        {
-            _writer.WriteCharEntity(ch);
-        }
-
-        public override void WriteWhitespace(string ws)
-        {
-            _writer.WriteWhitespace(ws);
-        }
-
-        public override void WriteString(string text)
-        {
-            _writer.WriteString(text);
-        }
-
-        public override void WriteSurrogateCharEntity(char lowChar, char highChar)
-        {
-            _writer.WriteSurrogateCharEntity(lowChar, highChar);
-        }
-
-        public override void WriteChars(char[] buffer, int index, int count)
-        {
-            _writer.WriteChars(buffer, index, count);
-        }
-        
-        public override void WriteRaw(char[] buffer, int index, int count)
-        {
-            _writer.WriteRaw(buffer, index, count);
-        }
-
-        public override void WriteRaw(string data)
-        {
-            _writer.WriteRaw(data);
-        }
-
-        public override void WriteBase64(byte[] buffer, int index, int count)
-        {
-            _writer.WriteBase64(buffer, index, count);
-        }
-        
         public override void Flush()
         {
             _writer.Flush();
@@ -175,7 +47,113 @@ namespace Intacct.SDK.Xml
             return _writer.LookupPrefix(ns);
         }
 
-        // XML Helper Functions
+        public void WriteAttribute(string localName, string value, bool writeNull = false)
+        {
+            if (!string.IsNullOrEmpty(value) || writeNull == true)
+            {
+                _writer.WriteAttributeString(localName, value);
+            }
+        }
+
+        public void WriteAttribute(string localName, int? value, bool writeNull = false)
+        {
+            if (value == null)
+            {
+                if (writeNull == true)
+                {
+                    _writer.WriteAttributeString(localName, "");
+                }
+            }
+            else
+            {
+                _writer.WriteAttributeString(localName, value.ToString());
+            }
+        }
+
+        public void WriteAttribute(string localName, bool value)
+        {
+            string val = (value == true) ? "true" : "false";
+            _writer.WriteAttributeString(localName, val);
+        }
+
+        public override void WriteBase64(byte[] buffer, int index, int count)
+        {
+            _writer.WriteBase64(buffer, index, count);
+        }
+
+        public override void WriteCData(string text)
+        {
+            _writer.WriteCData(text);
+        }
+
+        public override void WriteCharEntity(char ch)
+        {
+            _writer.WriteCharEntity(ch);
+        }
+
+        public override void WriteChars(char[] buffer, int index, int count)
+        {
+            _writer.WriteChars(buffer, index, count);
+        }
+
+        public override void WriteComment(string text)
+        {
+            _writer.WriteComment(text);
+        }
+
+        public void WriteCustomFieldsExplicit(Dictionary<string, dynamic> customFields)
+        {
+            if (customFields.Count > 0)
+            {
+                WriteStartElement("customfields");
+                foreach (KeyValuePair<string, dynamic> customField in customFields)
+                {
+                    WriteStartElement("customfield");
+                    WriteElement("customfieldname", customField.Key, true);
+
+                    if (customField.Value == null)
+                    {
+                        WriteEmptyElement("customfieldvalue");
+                    }
+                    else
+                    {
+                        WriteElement("customfieldvalue", customField.Value, true);
+                    }
+                    WriteEndElement(); //customfield
+                }
+                WriteEndElement(); //customfields
+            }
+        }
+
+        public void WriteCustomFieldsImplicit(Dictionary<string, dynamic> customFields)
+        {
+            if (customFields.Count > 0)
+            {
+                foreach (KeyValuePair<string, dynamic> customField in customFields)
+                {
+                    if (customField.Value == null)
+                    {
+                        WriteEmptyElement(customField.Key);
+                    }
+                    else
+                    {
+                        WriteElement(customField.Key, customField.Value, true);
+                    }
+                }
+            }
+        }
+
+        public void WriteDateSplitElements(DateTime date, bool writeNull = true)
+        {
+            WriteElement("year", date.ToString("yyyy"), writeNull);
+            WriteElement("month", date.ToString("MM"), writeNull);
+            WriteElement("day", date.ToString("dd"), writeNull);
+        }
+
+        public override void WriteDocType(string name, string pubid, string sysid, string subset)
+        {
+            _writer.WriteDocType(name, pubid, sysid, subset);
+        }
 
         public void WriteElement(string localName, string value, bool writeNull = false)
         {
@@ -193,6 +171,7 @@ namespace Intacct.SDK.Xml
             }
         }
 
+        // XML Helper Functions
         public void WriteElement(string localName, int value)
         {
             _writer.WriteElementString(localName, value.ToString());
@@ -257,7 +236,7 @@ namespace Intacct.SDK.Xml
                 }
             }
         }
-        
+
         public void WriteElement(string localName, DateTime value, string format = IntacctDateTimeFormat)
         {
             _writer.WriteElementString(localName, value == default(DateTime) ? "" : value.ToString(format));
@@ -283,85 +262,100 @@ namespace Intacct.SDK.Xml
             _writer.WriteStartElement(localName);
             _writer.WriteEndElement();
         }
-        
-        public void WriteAttribute(string localName, string value, bool writeNull = false)
-        {
-            if (!string.IsNullOrEmpty(value) || writeNull == true)
-            {
 
-                _writer.WriteAttributeString(localName, value);
-            }
+        public override void WriteEndAttribute()
+        {
+            _writer.WriteEndAttribute();
         }
 
-        public void WriteAttribute(string localName, int? value, bool writeNull = false)
+        public override void WriteEndDocument()
         {
-            if (value == null)
-            {
-                if (writeNull == true)
-                {
-                    _writer.WriteAttributeString(localName, "");
-                }
-            }
-            else
-            {
-                _writer.WriteAttributeString(localName, value.ToString());
-            }
+            _writer.WriteEndDocument();
         }
 
-        public void WriteAttribute(string localName, bool value)
+        public override void WriteEndElement()
         {
-            string val = (value == true) ? "true" : "false";
-            _writer.WriteAttributeString(localName, val);
+            _writer.WriteEndElement();
         }
 
-        public void WriteDateSplitElements(DateTime date, bool writeNull = true)
+        public override void WriteEntityRef(string name)
         {
-            WriteElement("year", date.ToString("yyyy"), writeNull);
-            WriteElement("month", date.ToString("MM"), writeNull);
-            WriteElement("day", date.ToString("dd"), writeNull);
+            _writer.WriteEntityRef(name);
         }
 
-        public void WriteCustomFieldsExplicit(Dictionary<string, dynamic> customFields)
+        public override void WriteFullEndElement()
         {
-            if (customFields.Count > 0)
-            {
-                WriteStartElement("customfields");
-                foreach (KeyValuePair<string, dynamic> customField in customFields)
-                {
-                    WriteStartElement("customfield");
-                    WriteElement("customfieldname", customField.Key, true);
-                    
-                    if (customField.Value == null)
-                    {
-                        WriteEmptyElement("customfieldvalue");
-                    }
-                    else
-                    {
-                        WriteElement("customfieldvalue", customField.Value, true);
-                    }
-                    WriteEndElement(); //customfield
-                }
-                WriteEndElement(); //customfields
-            }
+            _writer.WriteFullEndElement();
         }
 
-        public void WriteCustomFieldsImplicit(Dictionary<string, dynamic> customFields)
+        public override void WriteProcessingInstruction(string name, string text)
         {
-            if (customFields.Count > 0)
-            {
-                foreach (KeyValuePair<string, dynamic> customField in customFields)
-                {
-                    if (customField.Value == null)
-                    {
-                        WriteEmptyElement(customField.Key);
-                    }
-                    else
-                    {
-                        WriteElement(customField.Key, customField.Value, true);
-                    }
-                }
-            }
+            _writer.WriteProcessingInstruction(name, text);
         }
 
+        public override void WriteRaw(char[] buffer, int index, int count)
+        {
+            _writer.WriteRaw(buffer, index, count);
+        }
+
+        public override void WriteRaw(string data)
+        {
+            _writer.WriteRaw(data);
+        }
+
+        public new void WriteStartAttribute(string localName)
+        {
+            _writer.WriteStartAttribute(localName);
+        }
+
+        public new void WriteStartAttribute(string localName, string ns)
+        {
+            _writer.WriteStartAttribute(localName, ns);
+        }
+
+        public override void WriteStartAttribute(string prefix, string localName, string ns)
+        {
+            _writer.WriteStartAttribute(prefix, localName, ns);
+        }
+
+        public override void WriteStartDocument()
+        {
+            _writer.WriteStartDocument();
+        }
+
+        public override void WriteStartDocument(bool standalone)
+        {
+            _writer.WriteStartDocument(standalone);
+        }
+
+        public new void WriteStartElement(string localName)
+        {
+            _writer.WriteStartElement(localName);
+        }
+
+        public new void WriteStartElement(string localName, string ns)
+        {
+            _writer.WriteStartElement(localName, ns);
+        }
+
+        public override void WriteStartElement(string prefix, string localName, string ns)
+        {
+            _writer.WriteStartElement(prefix, localName, ns);
+        }
+
+        public override void WriteString(string text)
+        {
+            _writer.WriteString(text);
+        }
+
+        public override void WriteSurrogateCharEntity(char lowChar, char highChar)
+        {
+            _writer.WriteSurrogateCharEntity(lowChar, highChar);
+        }
+
+        public override void WriteWhitespace(string ws)
+        {
+            _writer.WriteWhitespace(ws);
+        }
     }
 }

--- a/Intacct.SDK/Xml/LoggingHandler.cs
+++ b/Intacct.SDK/Xml/LoggingHandler.cs
@@ -1,34 +1,33 @@
 ﻿/*
  * Copyright 2020 Sage Intacct, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
- * use this file except in compliance with the License. You may obtain a copy 
+ * use this file except in compliance with the License. You may obtain a copy
  * of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * or in the "LICENSE" file accompanying this file. This file is distributed on 
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
- * express or implied. See the License for the specific language governing 
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 
+using Intacct.SDK.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Intacct.SDK.Logging;
-using Microsoft.Extensions.Logging;
 
 namespace Intacct.SDK.Xml
 {
     public class LoggingHandler : DelegatingHandler
     {
         private ILogger _logger;
-        
-        private MessageFormatter _logMessageFormatter;
-        
+
         private LogLevel _logLevel;
+        private MessageFormatter _logMessageFormatter;
 
         public LoggingHandler(HttpMessageHandler innerHandler, ILogger logger, MessageFormatter logMessageFormat, LogLevel logLevel) : base(innerHandler)
         {
@@ -49,11 +48,10 @@ namespace Intacct.SDK.Xml
             catch (Exception ex)
             {
                 _logger.Log(_logLevel, ex, _logMessageFormatter.Format(request, response));
-                throw ex;
+                throw;
             }
 
             return response;
         }
-
     }
 }


### PR DESCRIPTION
Implementation of the non-legacy version of create accounts receivable payment through the API. This is specifically designed to expose, take advantage of the Description field, which is not available using the legacy API for AR payments. Added a new ArPaymentCreate2 class along with a ArPaymentCreate2Test unit test class. Reorganzied the LoggingHandler class. Reorganized the IaXmlWriter.cs class and added a new WriteDateMMddyyyy() convenience method.

Note, this PR builds upon the .NET 5.0 multi-targeting PR, previously submitted as a separate PR here:
https://github.com/Intacct/intacct-sdk-net/pull/155