### PR TITLE
Fix for Issue #160 BL01001973 Tax details are either missing or don't belong to the tax solution

### DIFF
--- a/Intacct.SDK.Tests/Functions/AccountsReceivable/InvoiceCreateTest.cs
+++ b/Intacct.SDK.Tests/Functions/AccountsReceivable/InvoiceCreateTest.cs
@@ -113,6 +113,7 @@ namespace Intacct.SDK.Tests.Functions.AccountsReceivable
         <exchratetype>Intacct Daily Rate</exchratetype>
         <nogl>false</nogl>
         <supdocid>6942</supdocid>
+        <taxsolutionid>taxsolution</taxsolutionid>
         <customfields>
             <customfield>
                 <customfieldname>customfield1</customfieldname>
@@ -123,6 +124,12 @@ namespace Intacct.SDK.Tests.Functions.AccountsReceivable
             <lineitem>
                 <glaccountno />
                 <amount>76343.43</amount>
+                <taxentries>
+                    <taxentry>
+                        <detailid>TaxName</detailid>
+                        <trx_tax>10</trx_tax>
+                    </taxentry>
+                </taxentries>
             </lineitem>
         </invoiceitems>
     </create_invoice>
@@ -150,6 +157,7 @@ namespace Intacct.SDK.Tests.Functions.AccountsReceivable
                 ExchangeRateType = "Intacct Daily Rate",
                 DoNotPostToGl = false,
                 AttachmentsId = "6942",
+                TaxSolutionId="taxsolution",
                 CustomFields = new Dictionary<string, dynamic>
                 {
                     { "customfield1", "customvalue1" }
@@ -161,6 +169,15 @@ namespace Intacct.SDK.Tests.Functions.AccountsReceivable
             {
                 TransactionAmount = 76343.43M
             };
+
+            InvoiceLineTaxEntriesCreate taxEntries = new InvoiceLineTaxEntriesCreate()
+            {
+                TaxId = "TaxName",
+                TaxValue = 10
+
+            };
+
+            line1.Taxentry.Add(taxEntries);
 
             record.Lines.Add(line1);
             

--- a/Intacct.SDK.Tests/Functions/AccountsReceivable/InvoiceLineCreateTest.cs
+++ b/Intacct.SDK.Tests/Functions/AccountsReceivable/InvoiceLineCreateTest.cs
@@ -85,6 +85,12 @@ namespace Intacct.SDK.Tests.Functions.AccountsReceivable
     <classid>Class1</classid>
     <contractid>Contract1</contractid>
     <warehouseid>Warehouse1</warehouseid>
+    <taxentries>
+        <taxentry>
+            <detailid>TaxName</detailid>
+            <trx_tax>10</trx_tax>
+        </taxentry>
+    </taxentries>
 </lineitem>";
 
             InvoiceLineCreate record = new InvoiceLineCreate() {
@@ -114,7 +120,16 @@ namespace Intacct.SDK.Tests.Functions.AccountsReceivable
                     { "customfield1", "customvalue1" }
                 }
             };
-            
+
+            InvoiceLineTaxEntriesCreate taxEntries = new InvoiceLineTaxEntriesCreate()
+            {
+                TaxId = "TaxName",
+                TaxValue = 10
+
+            };
+
+            record.Taxentry.Add(taxEntries);
+
             this.CompareXml(expected, record);
         }
     }

--- a/Intacct.SDK.Tests/Functions/AccountsReceivable/InvoiceLineTaxEntriesCreateTest.cs
+++ b/Intacct.SDK.Tests/Functions/AccountsReceivable/InvoiceLineTaxEntriesCreateTest.cs
@@ -1,0 +1,49 @@
+﻿using Intacct.SDK.Functions.AccountsReceivable;
+using Intacct.SDK.Tests.Xml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Intacct.SDK.Tests.Functions.AccountsReceivable
+{
+    public class InvoiceLineTaxEntriesCreateTest: XmlObjectTestHelper
+    {
+        [Fact]
+        public void GetXmlTest()
+        {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<taxentry>
+    <detailid>TaxName</detailid>
+</taxentry>";
+
+
+            InvoiceLineTaxEntriesCreate taxEntries = new InvoiceLineTaxEntriesCreate()
+            {
+                TaxId="TaxName"
+            };
+            
+            this.CompareXml(expected, taxEntries);
+        }
+        [Fact]
+        public void GetAllXmlTest()
+        {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<taxentry>
+    <detailid>TaxName</detailid>
+    <trx_tax>10</trx_tax>
+</taxentry>";
+            InvoiceLineTaxEntriesCreate taxEntries = new InvoiceLineTaxEntriesCreate()
+            {
+                TaxId = "TaxName",
+                TaxValue=10
+               
+            };
+
+            this.CompareXml(expected, taxEntries);
+        }
+
+        }
+}

--- a/Intacct.SDK/Functions/AccountsReceivable/AbstractInvoice.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/AbstractInvoice.cs
@@ -66,6 +66,8 @@ namespace Intacct.SDK.Functions.AccountsReceivable
 
         public string AttachmentsId;
 
+        public string TaxSolutionId;
+
         public List<AbstractInvoiceLine> Lines = new List<AbstractInvoiceLine>();
 
         public Dictionary<string, dynamic> CustomFields = new Dictionary<string, dynamic>();

--- a/Intacct.SDK/Functions/AccountsReceivable/AbstractInvoiceLine.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/AbstractInvoiceLine.cs
@@ -67,7 +67,11 @@ namespace Intacct.SDK.Functions.AccountsReceivable
         public string ContractId;
 
         public string WarehouseId;
-
+        //public AbstractInvoiceLineTaxEntries TaxEntries ;
+        //Made tax entries it as list because the API documentation showed multiple entries can be allowed for a line item  please see below comment
+        /*taxentries	Optional	taxentry[1...n]	Tax entries for the line. Required for VAT enabled transactions. Providing multiple entries is allowed if your tax solution supports it (AU and GB only). For ZA, only one tax entry is allowed.
+        */
+        public List<AbstractInvoiceLineTaxEntries> Taxentry = new List<AbstractInvoiceLineTaxEntries>();
         public Dictionary<string, dynamic> CustomFields = new Dictionary<string, dynamic>();
 
         protected AbstractInvoiceLine()

--- a/Intacct.SDK/Functions/AccountsReceivable/AbstractInvoiceLineTaxEntries.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/AbstractInvoiceLineTaxEntries.cs
@@ -1,0 +1,21 @@
+﻿using Intacct.SDK.Xml;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Intacct.SDK.Functions.AccountsReceivable
+{
+    public abstract class AbstractInvoiceLineTaxEntries : IXmlObject
+    {
+        public string TaxId;
+        public decimal? TaxValue;
+
+        public abstract void WriteXml(ref IaXmlWriter xml);
+
+        protected AbstractInvoiceLineTaxEntries()
+        {
+        }
+
+    }
+
+}

--- a/Intacct.SDK/Functions/AccountsReceivable/InvoiceCreate.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/InvoiceCreate.cs
@@ -82,6 +82,8 @@ namespace Intacct.SDK.Functions.AccountsReceivable
             xml.WriteElement("nogl", DoNotPostToGl);
             xml.WriteElement("supdocid", AttachmentsId);
 
+            xml.WriteElement("taxsolutionid", TaxSolutionId); 
+
             xml.WriteCustomFieldsExplicit(CustomFields);
 
             xml.WriteStartElement("invoiceitems");

--- a/Intacct.SDK/Functions/AccountsReceivable/InvoiceLineCreate.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/InvoiceLineCreate.cs
@@ -72,6 +72,18 @@ namespace Intacct.SDK.Functions.AccountsReceivable
             xml.WriteElement("contractid", ContractId);
             xml.WriteElement("warehouseid", WarehouseId);
 
+            
+            if (Taxentry.Count > 0)
+            {
+                xml.WriteStartElement("taxentries");
+                foreach (InvoiceLineTaxEntriesCreate taxEntry in Taxentry)
+                {
+                    taxEntry.WriteXml(ref xml);
+                }
+                xml.WriteEndElement(); //taxentries
+            }
+            
+
             xml.WriteEndElement(); //lineitem
         }
 

--- a/Intacct.SDK/Functions/AccountsReceivable/InvoiceLineTaxEntriesCreate.cs
+++ b/Intacct.SDK/Functions/AccountsReceivable/InvoiceLineTaxEntriesCreate.cs
@@ -1,0 +1,26 @@
+﻿using Intacct.SDK.Xml;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Intacct.SDK.Functions.AccountsReceivable
+{
+    public class InvoiceLineTaxEntriesCreate:AbstractInvoiceLineTaxEntries
+    {
+        public InvoiceLineTaxEntriesCreate()
+        {
+        }
+
+        public override void WriteXml(ref IaXmlWriter xml)
+        {
+            //xml.WriteStartElement("taxentries");
+            xml.WriteStartElement("taxentry");
+
+            xml.WriteElement("detailid", TaxId);
+            xml.WriteElement("trx_tax", TaxValue);
+
+            xml.WriteEndElement();//taxentry
+            //xml.WriteEndElement(); //taxentries
+        }
+    }
+}


### PR DESCRIPTION
Included provision to pass Tax details in Invoice Line items with Tax solution Id for creating a Sales Invoice

![image](https://user-images.githubusercontent.com/83342139/117173613-d98ca300-adc4-11eb-9132-b4b50027eccf.png)
