### PR TITLE
Allow clientconfig Entity ID to be used when not in credentials.ini

### DIFF
--- a/Intacct.SDK/Xml/Request/OperationBlock.cs
+++ b/Intacct.SDK/Xml/Request/OperationBlock.cs
@@ -44,7 +44,7 @@ namespace Intacct.SDK.Xml.Request
             else if (credentials != null && credentials.GetType() == typeof(LoginCredentials))
             {
                 LoginCredentials loginCreds = credentials as LoginCredentials;
-                this.Authentication = new LoginAuthentication(loginCreds.UserId, loginCreds.CompanyId, loginCreds.Password, loginCreds.EntityId);
+                this.Authentication = new LoginAuthentication(loginCreds.UserId, loginCreds.CompanyId, loginCreds.Password, loginCreds.EntityId ?? clientConfig.EntityId);
             }
             else if (!string.IsNullOrEmpty(clientConfig.SessionId))
             {


### PR DESCRIPTION
For specific update calls that need to be done under a location/entity but yet credentials.ini needs to stay at top level for reading objects