### PR TITLE
Override calculated VAT via linesubtotals object.

### DIFF
--- a/Intacct.SDK.Tests/Functions/InventoryControl/LineSubtotalTest.cs
+++ b/Intacct.SDK.Tests/Functions/InventoryControl/LineSubtotalTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
+using Intacct.SDK.Functions.OrderEntry;
+using Intacct.SDK.Functions;
+using Intacct.SDK.Tests.Xml;
+using Intacct.SDK.Xml;
+using Xunit;
+using Intacct.SDK.Functions.InventoryControl;
+
+namespace Intacct.SDK.Tests.Functions.InventoryControl
+{
+    public class LineSubtotalTest : XmlObjectTestHelper
+    {
+        [Fact]
+        public void GetXmlTest()
+        {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<linesubtotal>
+    <overridedetailid>GST</overridedetailid>
+    <trx_tax>17.5</trx_tax>
+</linesubtotal>";
+
+            var record = new LineSubtotal()
+            {
+                OverrideDetailId = "GST",
+                Trx_tax = 17.5m
+            };
+
+            this.CompareXml(expected, record);
+        }
+    }
+}

--- a/Intacct.SDK.Tests/Functions/OrderEntry/OrderEntryTransactionLineSubtotalTest.cs
+++ b/Intacct.SDK.Tests/Functions/OrderEntry/OrderEntryTransactionLineSubtotalTest.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
+using Intacct.SDK.Functions.InventoryControl;
+using Intacct.SDK.Functions.OrderEntry;
+using Intacct.SDK.Functions;
+using Intacct.SDK.Tests.Xml;
+using Intacct.SDK.Xml;
+using Xunit;
+
+namespace Intacct.SDK.Tests.Functions.OrderEntry
+{
+    public class OrderEntryTransactionLineSubtotalTest : XmlObjectTestHelper
+    {
+        [Fact]
+        public void GetAllXmlTest()
+        {
+            string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<sotransitem>
+    <bundlenumber>092304</bundlenumber>
+    <itemid>26323</itemid>
+    <itemdesc>Item Description</itemdesc>
+    <taxable>true</taxable>
+    <warehouseid>93294</warehouseid>
+    <quantity>2340</quantity>
+    <unit>593</unit>
+    <linelevelsimpletaxtype>Test</linelevelsimpletaxtype>
+    <discountpercent>10.00</discountpercent>
+    <price>32.35</price>
+    <discsurchargememo>None</discsurchargememo>
+    <locationid>SF</locationid>
+    <departmentid>Receiving</departmentid>
+    <memo>Memo</memo>
+    <customfields>
+        <customfield>
+            <customfieldname>customfield1</customfieldname>
+            <customfieldvalue>customvalue1</customfieldvalue>
+        </customfield>
+    </customfields>
+    <revrectemplate>template</revrectemplate>
+    <revrecstartdate>
+        <year>2015</year>
+        <month>06</month>
+        <day>30</day>
+    </revrecstartdate>
+    <revrecenddate>
+        <year>2015</year>
+        <month>07</month>
+        <day>31</day>
+    </revrecenddate>
+    <renewalmacro>Quarterly</renewalmacro>
+    <projectid>235</projectid>
+    <customerid>23423434</customerid>
+    <vendorid>797656</vendorid>
+    <employeeid>90295</employeeid>
+    <classid>243609</classid>
+    <contractid>9062</contractid>
+    <fulfillmentstatus>Complete</fulfillmentstatus>
+    <taskno>9850</taskno>
+    <billingtemplate>3525</billingtemplate>
+    <linesubtotals>
+        <linesubtotal>
+            <overridedetailid>GST</overridedetailid>
+            <trx_tax>17.5</trx_tax>
+        </linesubtotal>
+        <linesubtotal>
+            <overridedetailid>WET</overridedetailid>
+            <trx_tax>4.25</trx_tax>
+        </linesubtotal>
+    </linesubtotals>
+</sotransitem>";
+
+            OrderEntryTransactionLineCreate record = new OrderEntryTransactionLineCreate()
+            {
+                BundleNumber = "092304",
+                ItemId = "26323",
+                ItemDescription = "Item Description",
+                Taxable = true,
+                WarehouseId = "93294",
+                Quantity = 2340,
+                Unit = "593",
+                LineLevelSimpleTaxType = "Test",
+                DiscountPercent = 10.00M,
+                Price = 32.35M,
+                DiscountSurchargeMemo = "None",
+                Memo = "Memo",
+                RevRecTemplate = "template",
+                RevRecStartDate = new DateTime(2015, 06, 30),
+                RevRecEndDate = new DateTime(2015, 07, 31),
+                RenewalMacro = "Quarterly",
+                FulfillmentStatus = "Complete",
+                TaskNumber = "9850",
+                BillingTemplate = "3525",
+                LocationId = "SF",
+                DepartmentId = "Receiving",
+                ProjectId = "235",
+                CustomerId = "23423434",
+                VendorId = "797656",
+                EmployeeId = "90295",
+                ClassId = "243609",
+                ContractId = "9062",
+                CustomFields = new Dictionary<string, dynamic>
+                {
+                    { "customfield1", "customvalue1" }
+                }
+            };
+
+            record.LineSubtotals.Add(new LineSubtotal()
+            {
+                OverrideDetailId = "GST",
+                Trx_tax = 17.5m
+            });
+
+            record.LineSubtotals.Add(new LineSubtotal()
+            {
+                OverrideDetailId = "WET",
+                Trx_tax = 4.25m
+            });                        
+
+            this.CompareXml(expected, record);
+        }
+    }
+}

--- a/Intacct.SDK/Functions/InventoryControl/AbstractLineSubtotal.cs
+++ b/Intacct.SDK/Functions/InventoryControl/AbstractLineSubtotal.cs
@@ -1,0 +1,22 @@
+﻿using Intacct.SDK.Xml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intacct.SDK.Functions.InventoryControl
+{
+    public abstract class AbstractLineSubtotal : IXmlObject
+    {
+        public string OverrideDetailId;
+
+        public decimal? Trx_tax;
+
+        public abstract void WriteXml(ref IaXmlWriter xml);
+
+        protected AbstractLineSubtotal()
+        {
+        }
+    }
+}

--- a/Intacct.SDK/Functions/InventoryControl/LineSubtotal.cs
+++ b/Intacct.SDK/Functions/InventoryControl/LineSubtotal.cs
@@ -1,0 +1,20 @@
+﻿using Intacct.SDK.Xml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intacct.SDK.Functions.InventoryControl
+{
+    public class LineSubtotal : AbstractLineSubtotal
+    {
+        public override void WriteXml(ref IaXmlWriter xml)
+        {
+            xml.WriteStartElement("linesubtotal");
+            xml.WriteElement("overridedetailid", OverrideDetailId);
+            xml.WriteElement("trx_tax", Trx_tax);
+            xml.WriteEndElement();
+        }
+    }
+}

--- a/Intacct.SDK/Functions/OrderEntry/AbstractOrderEntryTransactionLine.cs
+++ b/Intacct.SDK/Functions/OrderEntry/AbstractOrderEntryTransactionLine.cs
@@ -83,6 +83,8 @@ namespace Intacct.SDK.Functions.OrderEntry
 
         public string ContractId;
 
+        public List<AbstractLineSubtotal> LineSubtotals = new List<AbstractLineSubtotal>();
+
         public Dictionary<string, dynamic> CustomFields = new Dictionary<string, dynamic>();
 
         protected AbstractOrderEntryTransactionLine()

--- a/Intacct.SDK/Functions/OrderEntry/OrderEntryTransactionLineCreate.cs
+++ b/Intacct.SDK/Functions/OrderEntry/OrderEntryTransactionLineCreate.cs
@@ -57,6 +57,16 @@ namespace Intacct.SDK.Functions.OrderEntry
                 xml.WriteEndElement(); //itemdetails
             }
 
+            if (LineSubtotals.Count > 0)
+            {
+                xml.WriteStartElement("linesubtotals");
+                foreach (AbstractLineSubtotal subtotal in LineSubtotals)
+                {
+                    subtotal.WriteXml(ref xml);
+                }
+                xml.WriteEndElement();
+            }
+
             xml.WriteCustomFieldsExplicit(CustomFields);
 
             xml.WriteElement("revrectemplate", RevRecTemplate);

--- a/Intacct.SDK/Functions/OrderEntry/OrderEntryTransactionLineUpdate.cs
+++ b/Intacct.SDK/Functions/OrderEntry/OrderEntryTransactionLineUpdate.cs
@@ -72,6 +72,16 @@ namespace Intacct.SDK.Functions.OrderEntry
                 xml.WriteEndElement(); //itemdetails
             }
 
+            if (LineSubtotals.Count > 0)
+            {
+                xml.WriteStartElement("linesubtotals");
+                foreach (AbstractLineSubtotal subtotal in LineSubtotals)
+                {
+                    subtotal.WriteXml(ref xml);
+                }
+                xml.WriteEndElement();
+            }
+
             xml.WriteCustomFieldsExplicit(CustomFields);
 
             xml.WriteElement("revrectemplate", RevRecTemplate);

--- a/Intacct.SDK/Functions/Purchasing/AbstractPurchasingTransactionLine.cs
+++ b/Intacct.SDK/Functions/Purchasing/AbstractPurchasingTransactionLine.cs
@@ -72,6 +72,8 @@ namespace Intacct.SDK.Functions.Purchasing
 
         public string ContractId;
 
+        public List<AbstractLineSubtotal> LineSubtotals = new List<AbstractLineSubtotal>();
+
         public Dictionary<string, dynamic> CustomFields = new Dictionary<string, dynamic>();
 
         protected AbstractPurchasingTransactionLine()

--- a/Intacct.SDK/Functions/Purchasing/PurchasingTransactionLineCreate.cs
+++ b/Intacct.SDK/Functions/Purchasing/PurchasingTransactionLineCreate.cs
@@ -64,6 +64,16 @@ namespace Intacct.SDK.Functions.Purchasing
                 xml.WriteEndElement(); //itemdetails
             }
 
+            if (LineSubtotals.Count > 0)
+            {
+                xml.WriteStartElement("linesubtotals");
+                foreach (AbstractLineSubtotal subtotal in LineSubtotals)
+                {
+                    subtotal.WriteXml(ref xml);
+                }
+                xml.WriteEndElement();
+            }
+
             xml.WriteElement("form1099", Form1099);
             xml.WriteElement("form1099type", Form1099Type);
             xml.WriteElement("form1099box", Form1099Box);

--- a/Intacct.SDK/Functions/Purchasing/PurchasingTransactionLineUpdate.cs
+++ b/Intacct.SDK/Functions/Purchasing/PurchasingTransactionLineUpdate.cs
@@ -77,6 +77,16 @@ namespace Intacct.SDK.Functions.Purchasing
                 xml.WriteEndElement(); //itemdetails
             }
 
+            if (LineSubtotals.Count > 0)
+            {
+                xml.WriteStartElement("linesubtotals");
+                foreach (AbstractLineSubtotal subtotal in LineSubtotals)
+                {
+                    subtotal.WriteXml(ref xml);
+                }
+                xml.WriteEndElement();
+            }
+
             xml.WriteElement("form1099", Form1099);
             xml.WriteElement("form1099type", Form1099Type);
             xml.WriteElement("form1099box", Form1099Box);


### PR DESCRIPTION
Support for Purchasing and Order Entry override calculated VAT.

https://developer.intacct.com/blog/2022/01/2022-Release-1.html#override-calculated-vat