### PR TITLE
Allow control of HttpMessageHandler lifetime. 

### DIFF
--- a/Intacct.SDK.Tests/OfflineClientTest.cs
+++ b/Intacct.SDK.Tests/OfflineClientTest.cs
@@ -50,7 +50,7 @@ namespace Intacct.SDK.Tests
                 SenderId = "testsender",
                 SenderPassword = "testsendpass",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig()
@@ -100,7 +100,7 @@ namespace Intacct.SDK.Tests
                 SenderId = "testsender",
                 SenderPassword = "testsendpass",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig()

--- a/Intacct.SDK.Tests/OnlineClientTest.cs
+++ b/Intacct.SDK.Tests/OnlineClientTest.cs
@@ -76,7 +76,7 @@ namespace Intacct.SDK.Tests
                 SenderId = "testsender",
                 SenderPassword = "testsendpass",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             OnlineClient client = new OnlineClient(clientConfig);
@@ -140,7 +140,7 @@ namespace Intacct.SDK.Tests
                 SenderId = "testsender",
                 SenderPassword = "testsendpass",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             OnlineClient client = new OnlineClient(clientConfig);
@@ -223,7 +223,7 @@ namespace Intacct.SDK.Tests
                 SenderId = "testsender",
                 SenderPassword = "testsendpass",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig()
@@ -303,7 +303,7 @@ namespace Intacct.SDK.Tests
                 SenderId = "testsender",
                 SenderPassword = "testsendpass",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
            //     Logger = LogManager.GetLogger(guid),
             };
 

--- a/Intacct.SDK.Tests/SessionProviderTest.cs
+++ b/Intacct.SDK.Tests/SessionProviderTest.cs
@@ -68,7 +68,7 @@ namespace Intacct.SDK.Tests
                 CompanyId = "testcompany",
                 UserId = "testuser",
                 UserPassword = "testpass",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             ClientConfig sessionCreds = await SessionProvider.Factory(config);
@@ -134,7 +134,7 @@ namespace Intacct.SDK.Tests
                 EntityId= "testentity",
                 UserId = "testuser",
                 UserPassword = "testpass",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             ClientConfig sessionCreds = await SessionProvider.Factory(config);
@@ -198,7 +198,7 @@ namespace Intacct.SDK.Tests
                 SenderPassword = "pass123!",
                 SessionId = "fAkESesSiOnId..",
                 EndpointUrl = "https://unittest.intacct.com/ia/xml/xmlgw.phtml",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             ClientConfig sessionCreds = await SessionProvider.Factory(config);
@@ -262,7 +262,7 @@ namespace Intacct.SDK.Tests
                 SenderPassword = "pass123!",
                 SessionId = "fAkESesSiOnId..",
                 EndpointUrl = "https://unittest.intacct.com/ia/xml/xmlgw.phtml",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
                 EntityId = "testentity",
             };
 
@@ -327,7 +327,7 @@ namespace Intacct.SDK.Tests
                 SenderPassword = "pass123!",
                 SessionId = "EntityAsession..",
                 EndpointUrl = "https://unittest.intacct.com/ia/xml/xmlgw.phtml",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
                 EntityId = "entityB",
             };
 
@@ -393,7 +393,7 @@ namespace Intacct.SDK.Tests
             {
                 SessionId = "fAkESesSiOnId..",
                 EndpointUrl = "https://unittest.intacct.com/ia/xml/xmlgw.phtml",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             ClientConfig sessionCreds = await SessionProvider.Factory(config);

--- a/Intacct.SDK.Tests/Xml/RequestHandlerTest.cs
+++ b/Intacct.SDK.Tests/Xml/RequestHandlerTest.cs
@@ -76,7 +76,7 @@ namespace Intacct.SDK.Tests.Xml
                 SenderId = "testsenderid",
                 SenderPassword = "pass123!",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig()
@@ -130,7 +130,7 @@ namespace Intacct.SDK.Tests.Xml
                 SenderId = "testsenderid",
                 SenderPassword = "pass123!",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig()
@@ -235,7 +235,7 @@ namespace Intacct.SDK.Tests.Xml
                 SenderId = "testsenderid",
                 SenderPassword = "pass123!",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig();
@@ -292,7 +292,7 @@ namespace Intacct.SDK.Tests.Xml
                 SenderId = "testsenderid",
                 SenderPassword = "pass123!",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig();
@@ -345,7 +345,7 @@ namespace Intacct.SDK.Tests.Xml
                 CompanyId = "badcompany",
                 UserId = "baduser",
                 UserPassword = "badpass",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig();
@@ -382,7 +382,7 @@ namespace Intacct.SDK.Tests.Xml
                 SenderId = "testsenderid",
                 SenderPassword = "pass123!",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
             };
 
             RequestConfig requestConfig = new RequestConfig();
@@ -460,7 +460,7 @@ namespace Intacct.SDK.Tests.Xml
                 SenderId = "testsenderid",
                 SenderPassword = "pass123!",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
          //       Logger = LogManager.GetLogger(guid),
             };
 
@@ -522,7 +522,7 @@ namespace Intacct.SDK.Tests.Xml
                 SenderId = "testsenderid",
                 SenderPassword = "pass123!",
                 SessionId = "testsession..",
-                MockHandler = mockHandler,
+                HttpMessageHandler = mockHandler,
                // LoggerFactory = new LogFactory(),
                  //   Logger = LogFactory<Program> //LogManager.GetLogger(guid),
             };

--- a/Intacct.SDK/ClientConfig.cs
+++ b/Intacct.SDK/ClientConfig.cs
@@ -18,6 +18,9 @@ using Intacct.SDK.Logging;
 using Intacct.SDK.Xml.Request;
 using Microsoft.Extensions.Logging;
 
+using System;
+using System.Net.Http;
+
 namespace Intacct.SDK
 {
     public class ClientConfig
@@ -51,8 +54,15 @@ namespace Intacct.SDK
 
         public MessageFormatter LogMessageFormatter;
 
-        public MockHandler MockHandler;
+        public HttpMessageHandler HttpMessageHandler;
 
+        [Obsolete("Use HttpMessageHandler instead.")]
+        public MockHandler MockHandler
+        {
+            get { return HttpMessageHandler as MockHandler;}
+            set { HttpMessageHandler = value;}
+        }
+         
         public ClientConfig()
         {
             this.LogLevel = LogLevel.Debug;

--- a/Intacct.SDK/Xml/RequestHandler.cs
+++ b/Intacct.SDK/Xml/RequestHandler.cs
@@ -86,15 +86,15 @@ namespace Intacct.SDK.Xml
         
         private HttpMessageHandler GetHttpMessageHandler()
         {
-            if (this.ClientConfig.MockHandler != null)
+            if (this.ClientConfig.HttpMessageHandler != null)
             {
                 if (this.ClientConfig.Logger != null)
                 {
-                    return new LoggingHandler(this.ClientConfig.MockHandler, this.ClientConfig.Logger, this.ClientConfig.LogMessageFormatter, this.ClientConfig.LogLevel);
+                    return new LoggingHandler(this.ClientConfig.HttpMessageHandler, this.ClientConfig.Logger, this.ClientConfig.LogMessageFormatter, this.ClientConfig.LogLevel);
                 }
                 else
                 {
-                    return this.ClientConfig.MockHandler;
+                    return this.ClientConfig.HttpMessageHandler;
                 }
             }
             else


### PR DESCRIPTION
The library currently creates a new HttpMessageHandler for each request. If you open up resource monitor, or use netstat you will start to see hundreds (or thousands) of open tcp connections. 

Background for this:

https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/

https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?redirectedfrom=MSDN&view=net-6.0#Remarks

This pull request changes the datatype and name in the ClientConfig to HttpMessageHandler. This allows a user who wishes to control lifetime of the handler to supply their own instance. 

Unit tests were updated to use the new generic name, with an obsolete property which points back to it to avoid breaking existing users. 

