### PR TITLE
Remove all XML formatting on RequestBlock WriteXml()

### DIFF
--- a/Intacct.SDK/Xml/RequestBlock.cs
+++ b/Intacct.SDK/Xml/RequestBlock.cs
@@ -42,7 +42,11 @@ namespace Intacct.SDK.Xml
             Stream stream = new MemoryStream();
             XmlWriterSettings xmlSettings = new XmlWriterSettings
             {
-                Encoding = this.Encoding
+                Encoding = this.Encoding,
+                Indent = false,
+                NewLineHandling = NewLineHandling.Replace,
+                NewLineOnAttributes = false
+                NewLineChars = ""
             };
 
             IaXmlWriter xml = new IaXmlWriter(stream, xmlSettings);


### PR DESCRIPTION
I was told to make this change and PR by Intacct's Director of Technical Support to deal with a performance issue we are seeing in API usage. 

The Engineering team wanted to make sure that the API request body is sent as one long unformatted string to reduce API request size to help keep requests under the 500k character limit.

https://developer.intacct.com/web-services/sync-vs-async/#asynchronous-responses