### PR TITLE
Updating Escape Quote Replacement and Tests

### DIFF
--- a/Intacct.SDK.Tests/Functions/Common/Query/Comparison/EqualTo/EqualToStringTest.cs
+++ b/Intacct.SDK.Tests/Functions/Common/Query/Comparison/EqualTo/EqualToStringTest.cs
@@ -54,7 +54,7 @@ namespace Intacct.SDK.Tests.Functions.Common.Query.Comparison.EqualTo
                 Value = "Bob's Pizza, Inc.",
             };
             
-            Assert.Equal("VENDORNAME = 'Bob\'s Pizza, Inc.'", condition.ToString());
+            Assert.Equal(@"VENDORNAME = 'Bob\'s Pizza, Inc.'", condition.ToString());
         }
     }
 }

--- a/Intacct.SDK.Tests/Functions/Common/Query/Comparison/GreaterThan/GreaterThanStringTest.cs
+++ b/Intacct.SDK.Tests/Functions/Common/Query/Comparison/GreaterThan/GreaterThanStringTest.cs
@@ -54,7 +54,7 @@ namespace Intacct.SDK.Tests.Functions.Common.Query.Comparison.GreaterThan
                 Value = "Bob's Pizza, Inc.",
             };
             
-            Assert.Equal("VENDORNAME > 'Bob\'s Pizza, Inc.'", condition.ToString());
+            Assert.Equal(@"VENDORNAME > 'Bob\'s Pizza, Inc.'", condition.ToString());
         }
     }
 }

--- a/Intacct.SDK.Tests/Functions/Common/Query/Comparison/GreaterThanOrEqualTo/GreaterThanOrEqualToStringTest.cs
+++ b/Intacct.SDK.Tests/Functions/Common/Query/Comparison/GreaterThanOrEqualTo/GreaterThanOrEqualToStringTest.cs
@@ -54,7 +54,7 @@ namespace Intacct.SDK.Tests.Functions.Common.Query.Comparison.GreaterThanOrEqual
                 Value = "Bob's Pizza, Inc.",
             };
             
-            Assert.Equal("VENDORNAME >= 'Bob\'s Pizza, Inc.'", condition.ToString());
+            Assert.Equal(@"VENDORNAME >= 'Bob\'s Pizza, Inc.'", condition.ToString());
         }
     }
 }

--- a/Intacct.SDK.Tests/Functions/Common/Query/Comparison/InList/InListStringTest.cs
+++ b/Intacct.SDK.Tests/Functions/Common/Query/Comparison/InList/InListStringTest.cs
@@ -70,7 +70,7 @@ namespace Intacct.SDK.Tests.Functions.Common.Query.Comparison.InList
                 }
             };
             
-            Assert.Equal("VENDORID IN ('bob\'s pizza','bill\'s pizza','sally\'s pizza')", condition.ToString());
+            Assert.Equal(@"VENDORID IN ('bob\'s pizza','bill\'s pizza','sally\'s pizza')", condition.ToString());
         }
         
         [Fact]

--- a/Intacct.SDK.Tests/Functions/Common/Query/Comparison/LessThan/LessThanStringTest.cs
+++ b/Intacct.SDK.Tests/Functions/Common/Query/Comparison/LessThan/LessThanStringTest.cs
@@ -54,7 +54,7 @@ namespace Intacct.SDK.Tests.Functions.Common.Query.Comparison.LessThan
                 Value = "Bob's Pizza, Inc.",
             };
             
-            Assert.Equal("VENDORNAME < 'Bob\'s Pizza, Inc.'", condition.ToString());
+            Assert.Equal(@"VENDORNAME < 'Bob\'s Pizza, Inc.'", condition.ToString());
         }
     }
 }

--- a/Intacct.SDK.Tests/Functions/Common/Query/Comparison/LessThanOrEqualTo/LessThanOrEqualToStringTest.cs
+++ b/Intacct.SDK.Tests/Functions/Common/Query/Comparison/LessThanOrEqualTo/LessThanOrEqualToStringTest.cs
@@ -54,7 +54,7 @@ namespace Intacct.SDK.Tests.Functions.Common.Query.Comparison.LessThanOrEqualTo
                 Value = "Bob's Pizza, Inc.",
             };
             
-            Assert.Equal("VENDORNAME <= 'Bob\'s Pizza, Inc.'", condition.ToString());
+            Assert.Equal(@"VENDORNAME <= 'Bob\'s Pizza, Inc.'", condition.ToString());
         }
     }
 }

--- a/Intacct.SDK.Tests/Functions/Common/Query/Comparison/Like/LikeStringTest.cs
+++ b/Intacct.SDK.Tests/Functions/Common/Query/Comparison/Like/LikeStringTest.cs
@@ -54,7 +54,7 @@ namespace Intacct.SDK.Tests.Functions.Common.Query.Comparison.Like
                 Value = "%ob's Pizza%",
             };
             
-            Assert.Equal("VENDORNAME LIKE '%ob\'s Pizza%'", condition.ToString());
+            Assert.Equal(@"VENDORNAME LIKE '%ob\'s Pizza%'", condition.ToString());
         }
     }
 }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/EqualTo/EqualToString.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/EqualTo/EqualToString.cs
@@ -25,7 +25,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.EqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " = '" + Value.Replace("'", "\'") + "'";
+            clause = clause + Field + " = '" + Value.Replace("'", "\\'") + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThan/GreaterThanString.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThan/GreaterThanString.cs
@@ -25,7 +25,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThan
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " > '" + Value.Replace("'", "\'") + "'";
+            clause = clause + Field + " > '" + Value.Replace("'", "\\'") + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThanOrEqualTo/GreaterThanOrEqualToString.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThanOrEqualTo/GreaterThanOrEqualToString.cs
@@ -25,7 +25,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThanOrEqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " >= '" + Value.Replace("'", "\'") + "'";
+            clause = clause + Field + " >= '" + Value.Replace("'", "\\'") + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/InList/InListString.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/InList/InListString.cs
@@ -32,7 +32,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.InList
             List<string> pieces = new List<string>();
             foreach (string piece in ValuesList)
             {
-                pieces.Add("'" + piece.Replace("'", "\'") + "'");
+                pieces.Add("'" + piece.Replace("'", "\\'") + "'");
             }
             
             clause =  Field + notClause + " IN (" + string.Join(",", pieces) + ")";

--- a/Intacct.SDK/Functions/Common/Query/Comparison/LessThan/LessThanString.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/LessThan/LessThanString.cs
@@ -25,7 +25,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThan
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " < '" + Value.Replace("'", "\'") + "'";
+            clause = clause + Field + " < '" + Value.Replace("'", "\\'") + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/LessThanOrEqualTo/LessThanOrEqualToString.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/LessThanOrEqualTo/LessThanOrEqualToString.cs
@@ -25,7 +25,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThanOrEqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " <= '" + Value.Replace("'", "\'") + "'";
+            clause = clause + Field + " <= '" + Value.Replace("'", "\\'") + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/Like/LikeString.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/Like/LikeString.cs
@@ -25,7 +25,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.Like
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " LIKE '" + Value.Replace("'", "\'") + "'";
+            clause = clause + Field + " LIKE '" + Value.Replace("'", "\\'") + "'";
 
             return clause;
         }


### PR DESCRIPTION
### Background
When using the Sage Intacct SDK comparison classes for strings, single quotes were not being escaped. For example, the string "Bob's Pizza, Inc." would be converted to "Bob's Pizza, Inc." instead of "Bob\'s Pizza, Inc.". This change updates the value "\\'" with "\\\\'" in each string.Replace(), so that the single quote can be properly escaped. The tests for escaped single quotes were also updated to reflect this change. 

### Testing
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
[xUnit.net 00:00:41.82]     Intacct.SDK.Tests.Xml.RequestHandlerTest.MockExecuteWithDebugLoggerTest [SKIP]
[xUnit.net 00:00:41.82]     Intacct.SDK.Tests.OnlineClientTest.LoggerTest [SKIP]
  Skipped Intacct.SDK.Tests.Xml.RequestHandlerTest.MockExecuteWithDebugLoggerTest [1 ms]
  Skipped Intacct.SDK.Tests.OnlineClientTest.LoggerTest [1 ms]
[xUnit.net 00:00:41.82]     Intacct.SDK.Tests.Xml.RequestHandlerTest.MockExecuteOfflineWithSessionCredsTest [SKIP]
  Skipped Intacct.SDK.Tests.Xml.RequestHandlerTest.MockExecuteOfflineWithSessionCredsTest [1 ms]

Passed!  - Failed:     0, Passed:   497, Skipped:     3, Total:   500, Duration: 205 ms - Intacct.SDK.Tests.dll (netcoreapp3.1)