### PR TITLE
Message formatter stream does not support reading

### DIFF
--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -203,11 +203,9 @@ namespace Intacct.SDK.Logging
 
         private async Task<string> GetHttpContentAsString(HttpContent httpContent)
         {
-            using var stream = await httpContent.ReadAsStreamAsync();
+            var bytes = await httpContent.ReadAsByteArrayAsync();
 
-            using var reader = new StreamReader(stream, Encoding.UTF8);
-
-            return await reader.ReadToEndAsync();
+            return Encoding.UTF8.GetString(bytes);
         }
     }
 }

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -71,7 +71,7 @@ namespace Intacct.SDK.Logging
 
         public string Format(HttpRequestMessage request, HttpResponseMessage response, Exception error = null)
         {
-            string message = Regex.Replace(_template, @"{\s*([A-Za-z_\-\.0-9]+)\s*}",  match => {
+            string message = Regex.Replace(_template, @"{\s*([A-Za-z_\-\.0-9]+)\s*}", match => {
                 string result = "";
                 switch (match.Value)
                 {
@@ -84,8 +84,6 @@ namespace Intacct.SDK.Logging
                         {
                             result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                         }
-
-
 
                         result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
                         break;
@@ -102,8 +100,6 @@ namespace Intacct.SDK.Logging
                             }
 
                             result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
-
-
                         }
                         break;
                     case "{req_headers}":

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Intacct.SDK.Xml.Response;
@@ -204,7 +205,7 @@ namespace Intacct.SDK.Logging
         {
             using var stream = await httpContent.ReadAsStreamAsync();
 
-            using var reader = new StreamReader(stream);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
 
             return await reader.ReadToEndAsync();
         }

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -84,7 +84,6 @@ namespace Intacct.SDK.Logging
                         {
                             result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                         }
-
                         result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
                         break;
                     case "{response}":
@@ -98,7 +97,6 @@ namespace Intacct.SDK.Logging
                             {
                                 result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                             }
-
                             result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
                         }
                         break;

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -85,7 +85,7 @@ namespace Intacct.SDK.Logging
                         {
                             result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                         }
-                        result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
+                        result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(request.Content).Result;
                         break;
                     case "{response}":
                         result = response != null ? " HTTP/" + response.Version.ToString()

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -71,7 +71,7 @@ namespace Intacct.SDK.Logging
 
         public string Format(HttpRequestMessage request, HttpResponseMessage response, Exception error = null)
         {
-            string message = Regex.Replace(_template, @"{\s*([A-Za-z_\-\.0-9]+)\s*}", async match => {
+            string message = Regex.Replace(_template, @"{\s*([A-Za-z_\-\.0-9]+)\s*}",  match => {
                 string result = "";
                 switch (match.Value)
                 {

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -21,7 +21,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Intacct.SDK.Xml.Response;
 
 namespace Intacct.SDK.Logging
 {

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -20,6 +20,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Intacct.SDK.Xml.Response;
 
 namespace Intacct.SDK.Logging
 {
@@ -86,7 +87,7 @@ namespace Intacct.SDK.Logging
 
 
 
-                        result = result + Environment.NewLine + Environment.NewLine + request.Content.ReadAsStreamAsync().Result;
+                        result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
                         break;
                     case "{response}":
                         result = response != null ? " HTTP/" + response.Version.ToString()
@@ -100,21 +101,9 @@ namespace Intacct.SDK.Logging
                                 result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                             }
 
-                            if (response.Content is StringContent stringContent)
-                            {
-                                result = result + Environment.NewLine + Environment.NewLine + stringContent.ReadAsStringAsync();
-                            }
-                            else
-                            {
-                                using var stream = await response.Content.ReadAsStreamAsync();
+                            result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
 
-                                using var reader = new StreamReader(stream);
 
-                                result = await reader.ReadToEndAsync();
-
-                            }
-
-                           
                         }
                         break;
                     case "{req_headers}":
@@ -219,6 +208,13 @@ namespace Intacct.SDK.Logging
 
 
 
+        private async Task<string> GetHttpContentAsString(HttpContent httpContent)
+        {
+            using var stream = await httpContent.ReadAsStreamAsync();
 
+            using var reader = new StreamReader(stream);
+
+            return await reader.ReadToEndAsync();
+        }
     }
 }

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -200,8 +200,6 @@ namespace Intacct.SDK.Logging
             return message;
         }
 
-
-
         private async Task<string> GetHttpContentAsString(HttpContent httpContent)
         {
             using var stream = await httpContent.ReadAsStreamAsync();


### PR DESCRIPTION
Hello,

Been getting this error with Stack trace  when using the Intacct .NET SDK. The error seems to be stemming from the ContentReadAsStringAsync(). In certain sporadic cases, the error is thrown, even when the previous logging were successful

This issue only happens when logging is enabled for the SDK.  

Error:

StackTrace:


