### PR TITLE
Message formatter stream does not support reading

### DIFF
--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -203,11 +203,9 @@ namespace Intacct.SDK.Logging
 
         private async Task<string> GetHttpContentAsString(HttpContent httpContent)
         {
-            using var stream = await httpContent.ReadAsStreamAsync();
+            var bytes = await httpContent.ReadAsByteArrayAsync();
 
-            using var reader = new StreamReader(stream, Encoding.UTF8);
-
-            return await reader.ReadToEndAsync();
+            return Encoding.UTF8.GetString(bytes);
         }
     }
 }

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -71,7 +71,7 @@ namespace Intacct.SDK.Logging
 
         public string Format(HttpRequestMessage request, HttpResponseMessage response, Exception error = null)
         {
-            string message = Regex.Replace(_template, @"{\s*([A-Za-z_\-\.0-9]+)\s*}",  match => {
+            string message = Regex.Replace(_template, @"{\s*([A-Za-z_\-\.0-9]+)\s*}", match => {
                 string result = "";
                 switch (match.Value)
                 {
@@ -84,8 +84,6 @@ namespace Intacct.SDK.Logging
                         {
                             result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                         }
-
-
 
                         result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
                         break;
@@ -102,8 +100,6 @@ namespace Intacct.SDK.Logging
                             }
 
                             result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
-
-
                         }
                         break;
                     case "{req_headers}":

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -84,7 +84,7 @@ namespace Intacct.SDK.Logging
                         {
                             result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                         }
-                        result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(request.Content).Result;
+                        result = result + Environment.NewLine + Environment.NewLine + request.Content.ReadAsStringAsync().Result;
                         break;
                     case "{response}":
                         result = response != null ? " HTTP/" + response.Version.ToString()
@@ -97,7 +97,7 @@ namespace Intacct.SDK.Logging
                             {
                                 result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                             }
-                            result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
+                            result = result + Environment.NewLine + Environment.NewLine + request.Content.ReadAsStringAsync().Result;
                         }
                         break;
                     case "{req_headers}":

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Intacct.SDK.Xml.Response;
@@ -204,7 +205,7 @@ namespace Intacct.SDK.Logging
         {
             using var stream = await httpContent.ReadAsStreamAsync();
 
-            using var reader = new StreamReader(stream);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
 
             return await reader.ReadToEndAsync();
         }

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -84,7 +84,6 @@ namespace Intacct.SDK.Logging
                         {
                             result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                         }
-
                         result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
                         break;
                     case "{response}":
@@ -98,7 +97,6 @@ namespace Intacct.SDK.Logging
                             {
                                 result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                             }
-
                             result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
                         }
                         break;

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -85,7 +85,7 @@ namespace Intacct.SDK.Logging
                         {
                             result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                         }
-                        result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
+                        result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(request.Content).Result;
                         break;
                     case "{response}":
                         result = response != null ? " HTTP/" + response.Version.ToString()

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -71,7 +71,7 @@ namespace Intacct.SDK.Logging
 
         public string Format(HttpRequestMessage request, HttpResponseMessage response, Exception error = null)
         {
-            string message = Regex.Replace(_template, @"{\s*([A-Za-z_\-\.0-9]+)\s*}", async match => {
+            string message = Regex.Replace(_template, @"{\s*([A-Za-z_\-\.0-9]+)\s*}",  match => {
                 string result = "";
                 switch (match.Value)
                 {

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -21,7 +21,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Intacct.SDK.Xml.Response;
 
 namespace Intacct.SDK.Logging
 {

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -20,6 +20,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Intacct.SDK.Xml.Response;
 
 namespace Intacct.SDK.Logging
 {
@@ -86,7 +87,7 @@ namespace Intacct.SDK.Logging
 
 
 
-                        result = result + Environment.NewLine + Environment.NewLine + request.Content.ReadAsStreamAsync().Result;
+                        result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
                         break;
                     case "{response}":
                         result = response != null ? " HTTP/" + response.Version.ToString()
@@ -100,21 +101,9 @@ namespace Intacct.SDK.Logging
                                 result = result + Environment.NewLine + "{" + header.Key + "}: " + string.Join(", ", header.Value);
                             }
 
-                            if (response.Content is StringContent stringContent)
-                            {
-                                result = result + Environment.NewLine + Environment.NewLine + stringContent.ReadAsStringAsync();
-                            }
-                            else
-                            {
-                                using var stream = await response.Content.ReadAsStreamAsync();
+                            result = result + Environment.NewLine + Environment.NewLine + GetHttpContentAsString(response.Content).Result;
 
-                                using var reader = new StreamReader(stream);
 
-                                result = await reader.ReadToEndAsync();
-
-                            }
-
-                           
                         }
                         break;
                     case "{req_headers}":
@@ -219,6 +208,13 @@ namespace Intacct.SDK.Logging
 
 
 
+        private async Task<string> GetHttpContentAsString(HttpContent httpContent)
+        {
+            using var stream = await httpContent.ReadAsStreamAsync();
 
+            using var reader = new StreamReader(stream);
+
+            return await reader.ReadToEndAsync();
+        }
     }
 }

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -200,8 +200,6 @@ namespace Intacct.SDK.Logging
             return message;
         }
 
-
-
         private async Task<string> GetHttpContentAsString(HttpContent httpContent)
         {
             using var stream = await httpContent.ReadAsStreamAsync();

--- a/Intacct.SDK/Xml/RequestHandler.cs
+++ b/Intacct.SDK/Xml/RequestHandler.cs
@@ -99,10 +99,8 @@ namespace Intacct.SDK.Xml
             }
             else
             {
-                HttpClientHandler httpClientHandler = new HttpClientHandler()
-                {
-                    AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate
-                };
+                HttpClientHandler httpClientHandler = new HttpClientHandler();
+
                 
                 if (this.ClientConfig.Logger != null)
                 {
@@ -122,15 +120,14 @@ namespace Intacct.SDK.Xml
 
         private async Task<Stream> Execute(Stream requestXml)
         {
-            HttpClient client = new HttpClient(GetHttpMessageHandler());
-            client.Timeout = this.RequestConfig.MaxTimeout;
-            client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip,deflate");
-            client.DefaultRequestHeaders.UserAgent.ParseAdd("intacct-sdk-net-client/" + RequestHandler.Version);
+                HttpClient client = new HttpClient(GetHttpMessageHandler());
+                client.Timeout = this.RequestConfig.MaxTimeout;
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("intacct-sdk-net-client/" + RequestHandler.Version);
 
-            requestXml.Position = 0;
-            StreamContent content = new StreamContent(requestXml);
-            content.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
-            
+                requestXml.Position = 0;
+                StreamContent content = new StreamContent(requestXml);
+                content.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
+
             for (int attempt = 0; attempt <= this.RequestConfig.MaxRetries; attempt++)
             {
                 if (attempt > 0)


### PR DESCRIPTION
Hello,

We have been sporadically getting this error with the stack trace below when logging the api request and response. This is due to the MemoryStream property CanRead being set to false when converting to a GzipStream/DeflateStream.  Instead of decompressing from GzipStream/DeflateStream, would like to propose removing them from the AutomaticDecompression and Accepted-Encoding.

I have opened up a separate issue with Microsoft regarding this[ here](https://github.com/dotnet/core/issues/8589)




System.AggregateException:
   at System.Threading.Tasks.Task.ThrowIfExceptional (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Threading.Tasks.Task`1.GetResultCore (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Threading.Tasks.Task`1.get_Result (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Intacct.SDK.Logging.MessageFormatter+<>c__DisplayClass6_0.<Format>b__0 (Intacct.SDK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
   at System.Text.RegularExpressions.Regex+<>c.<Replace>b__84_0 (System.Text.RegularExpressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Text.RegularExpressions.RegexRunner.Scan (System.Text.RegularExpressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Text.RegularExpressions.Regex.Run (System.Text.RegularExpressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Text.RegularExpressions.Regex.Replace (System.Text.RegularExpressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Text.RegularExpressions.Regex.Replace (System.Text.RegularExpressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Text.RegularExpressions.Regex.Replace (System.Text.RegularExpressions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at Intacct.SDK.Logging.MessageFormatter.Format (Intacct.SDK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
   at Intacct.SDK.Xml.LoggingHandler+<SendAsync>d__4.MoveNext (Intacct.SDK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter.GetResult (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Net.Http.HttpClient+<<SendAsync>g__Core|83_0>d.MoveNext (System.Net.Http, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter.GetResult (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Intacct.SDK.Xml.RequestHandler+<Execute>d__9.MoveNext (Intacct.SDK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter.GetResult (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Intacct.SDK.Xml.RequestHandler+<ExecuteOnline>d__5.MoveNext (Intacct.SDK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter.GetResult (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Intacct.SDK.AbstractClient+<ExecuteOnlineRequest>d__3.MoveNext (Intacct.SDK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter.GetResult (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Intacct.SDK.OnlineClient+<ExecuteBatch>d__2.MoveNext (Intacct.SDK, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at Epilink.Functions.IntacctPayrollExport.Services.IntacctService+<ExportTimeExpenseTransactionsBatch>d__3.MoveNext (Epilink.Functions.IntacctPayrollExport, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null: D:\a\1\s\Epilink.Functions.IntacctPayrollExport\Services\IntacctService.cs:35)
Inner exception System.ArgumentException handled at System.Threading.Tasks.Task.ThrowIfExceptional:
   at System.IO.Compression.DeflateStream..ctor (System.IO.Compression, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.IO.Compression.GZipStream..ctor (System.IO.Compression, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.IO.Compression.GZipStream..ctor (System.IO.Compression, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Net.Http.DecompressionHandler+GZipDecompressedContent.GetDecompressedStream (System.Net.Http, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Net.Http.DecompressionHandler+DecompressedContent.TryCreateContentReadStream (System.Net.Http, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Net.Http.DecompressionHandler+DecompressedContent+<SerializeToStreamAsync>d__6.MoveNext (System.Net.Http, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable+ConfiguredTaskAwaiter.GetResult (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Net.Http.HttpContent+<LoadIntoBufferAsyncCore>d__63.MoveNext (System.Net.Http, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable+ConfiguredTaskAwaiter.GetResult (System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.Net.Http.HttpContent+<WaitAndReturnAsync>d__82`2.MoveNext (System.Net.Http, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
