### PR TITLE
Fix DateTime formatting

### DIFF
--- a/Intacct.SDK.Tests/Intacct.SDK.Tests.csproj
+++ b/Intacct.SDK.Tests/Intacct.SDK.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Intacct.SDK.Tests/Xml/RequestHandlerTest.cs
+++ b/Intacct.SDK.Tests/Xml/RequestHandlerTest.cs
@@ -396,7 +396,7 @@ namespace Intacct.SDK.Tests.Xml
             
             var ex = await Record.ExceptionAsync(() => requestHandler.ExecuteOnline(contentBlock));
             Assert.IsType<HttpRequestException>(ex);
-            Assert.Equal("Response status code does not indicate success: 524 ().", ex.Message);
+            Assert.Equal("Response status code does not indicate success: 524.", ex.Message);
         }
 
         [Fact(Skip="test randomly failing")]

--- a/Intacct.SDK/Functions/AccountsPayable/ApPaymentCreate.cs
+++ b/Intacct.SDK/Functions/AccountsPayable/ApPaymentCreate.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
 using Intacct.SDK.Xml;
 
 namespace Intacct.SDK.Functions.AccountsPayable

--- a/Intacct.SDK/Functions/Common/Query/Comparison/EqualTo/EqualToDate.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/EqualTo/EqualToDate.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.EqualTo
 {
     public class EqualToDate : AbstractDate
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.EqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " = '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " = '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/EqualTo/EqualToDateTime.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/EqualTo/EqualToDateTime.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.EqualTo
 {
     public class EqualToDateTime : AbstractDateTime
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.EqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " = '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " = '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThan/GreaterThanDate.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThan/GreaterThanDate.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThan
 {
     public class GreaterThanDate : AbstractDate
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThan
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " > '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " > '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThan/GreaterThanDateTime.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThan/GreaterThanDateTime.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThan
 {
     public class GreaterThanDateTime : AbstractDateTime
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThan
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " > '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " > '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThanOrEqualTo/GreaterThanOrEqualToDate.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThanOrEqualTo/GreaterThanOrEqualToDate.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThanOrEqualTo
 {
     public class GreaterThanOrEqualToDate : AbstractDate
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThanOrEqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " >= '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " >= '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThanOrEqualTo/GreaterThanOrEqualToDateTime.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/GreaterThanOrEqualTo/GreaterThanOrEqualToDateTime.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThanOrEqualTo
 {
     public class GreaterThanOrEqualToDateTime : AbstractDateTime
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.GreaterThanOrEqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " >= '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " >= '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/LessThan/LessThanDate.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/LessThan/LessThanDate.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThan
 {
     public class LessThanDate : AbstractDate
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThan
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " < '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " < '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/LessThan/LessThanDateTime.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/LessThan/LessThanDateTime.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThan
 {
     public class LessThanDateTime : AbstractDateTime
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThan
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " < '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " < '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/LessThanOrEqualTo/LessThanOrEqualToDate.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/LessThanOrEqualTo/LessThanOrEqualToDate.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThanOrEqualTo
 {
     public class LessThanOrEqualToDate : AbstractDate
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThanOrEqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " <= '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " <= '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Common/Query/Comparison/LessThanOrEqualTo/LessThanOrEqualToDateTime.cs
+++ b/Intacct.SDK/Functions/Common/Query/Comparison/LessThanOrEqualTo/LessThanOrEqualToDateTime.cs
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+using System.Globalization;
+
 namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThanOrEqualTo
 {
     public class LessThanOrEqualToDateTime : AbstractDateTime
@@ -25,7 +27,7 @@ namespace Intacct.SDK.Functions.Common.Query.Comparison.LessThanOrEqualTo
                 clause = "NOT ";
             }
             
-            clause = clause + Field + " <= '" + Value.ToString(Format) + "'";
+            clause = clause + Field + " <= '" + Value.ToString(Format, CultureInfo.InvariantCulture) + "'";
 
             return clause;
         }

--- a/Intacct.SDK/Functions/Projects/TimesheetUpdate.cs
+++ b/Intacct.SDK/Functions/Projects/TimesheetUpdate.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * Copyright 2022 Sage Intacct, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. You may obtain a copy 
+ * of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * or in the "LICENSE" file accompanying this file. This file is distributed on 
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+ * express or implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+using Intacct.SDK.Xml;
+
+namespace Intacct.SDK.Functions.Projects
+{
+    public class TimesheetUpdate : AbstractTimesheet
+    {
+
+        public TimesheetUpdate(string controlId = null) : base(controlId)
+        {
+        }
+
+        public override void WriteXml(ref IaXmlWriter xml)
+        {
+            xml.WriteStartElement("function");
+            xml.WriteAttribute("controlid", ControlId, true);
+
+            xml.WriteStartElement("update");
+            xml.WriteStartElement("TIMESHEET");
+
+            xml.WriteElement("EMPLOYEEID", EmployeeId, true);
+            xml.WriteElement("BEGINDATE", BeginDate, IaXmlWriter.IntacctDateFormat);
+            
+            xml.WriteElement("DESCRIPTION", Description);
+            xml.WriteElement("SUPDOCID", AttachmentsId);
+            xml.WriteElement("STATE", Action);
+
+            xml.WriteStartElement("TIMESHEETENTRIES");
+            if (Entries.Count > 0)
+            {
+                foreach (TimesheetEntryCreate entry in Entries)
+                {
+                    entry.WriteXml(ref xml);
+                }
+            }
+            xml.WriteEndElement(); //TIMESHEETENTRIES
+
+            xml.WriteCustomFieldsImplicit(CustomFields);
+
+            xml.WriteEndElement(); //TIMESHEET
+            xml.WriteEndElement(); //update
+
+            xml.WriteEndElement(); //function
+        }
+
+    }
+}

--- a/Intacct.SDK/Logging/MessageFormatter.cs
+++ b/Intacct.SDK/Logging/MessageFormatter.cs
@@ -118,10 +118,10 @@ namespace Intacct.SDK.Logging
                         result = response.Content.Headers.ContentLength.ToString();
                         break;
                     case "{req_body}":
-                        result = request.Content.ToString();
+                        result = request.Content.ReadAsStringAsync().Result;
                         break;
                     case "{res_body}":
-                        result = response != null ? response.Content.ToString() : "NULL";
+                        result = response != null ? response.Content.ReadAsStringAsync().Result : "NULL";
                         break;
                     case "{ts}":
                     case "{date_iso_8601}":

--- a/Intacct.SDK/Xml/IaXmlWriter.cs
+++ b/Intacct.SDK/Xml/IaXmlWriter.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Xml;
@@ -260,7 +261,7 @@ namespace Intacct.SDK.Xml
         
         public void WriteElement(string localName, DateTime value, string format = IntacctDateTimeFormat)
         {
-            _writer.WriteElementString(localName, value == default(DateTime) ? "" : value.ToString(format));
+            _writer.WriteElementString(localName, value == default(DateTime) ? "" : value.ToString(format, CultureInfo.InvariantCulture));
         }
 
         public void WriteElement(string localName, DateTime? value, string format = IntacctDateTimeFormat, bool writeNull = false)
@@ -274,7 +275,7 @@ namespace Intacct.SDK.Xml
             }
             else
             {
-                _writer.WriteElementString(localName, value == default(DateTime) ? "" : value.Value.ToString(format));
+                _writer.WriteElementString(localName, value == default(DateTime) ? "" : value.Value.ToString(format, CultureInfo.InvariantCulture));
             }
         }
 


### PR DESCRIPTION
The DateTime formatting is broken because it doesn't specify InvariantCulture, basically changing slashes into dashes depending on your system.

Also fixed a broken unit test and added a missing TimesheetUpdate function.